### PR TITLE
feat: add EXA_API_KEY support for Exa MCP authentication

### DIFF
--- a/agents/pal.py
+++ b/agents/pal.py
@@ -41,8 +41,9 @@ data_dir.mkdir(parents=True, exist_ok=True)
 duckdb_path = str(data_dir / "pal.db")
 
 # Exa MCP for research
+EXA_API_KEY = getenv("EXA_API_KEY", "")
 EXA_MCP_URL = (
-    "https://mcp.exa.ai/mcp?tools="
+    f"https://mcp.exa.ai/mcp?exaApiKey={EXA_API_KEY}&tools="
     "web_search_exa,"
     "get_code_context_exa,"
     "company_research_exa,"

--- a/compose.yaml
+++ b/compose.yaml
@@ -39,6 +39,7 @@ services:
       WAIT_FOR_DB: "True"
       PRINT_ENV_ON_LOAD: "True"
       OPENAI_API_KEY: ${OPENAI_API_KEY}
+      EXA_API_KEY: ${EXA_API_KEY:-}
     depends_on:
       - agentos-db
     networks:

--- a/example.env
+++ b/example.env
@@ -5,6 +5,9 @@ OPENAI_API_KEY=sk-***
 # ANTHROPIC_API_KEY=sk-ant-***
 # GOOGLE_API_KEY=***
 
+# Exa API key for web research
+# EXA_API_KEY=***
+
 # Database (defaults work out of the box)
 # DB_USER=ai
 # DB_PASS=ai


### PR DESCRIPTION
## Summary

Add support for authenticating with Exa's MCP endpoint using the `EXA_API_KEY` environment variable.

**Changes:**
- `agents/pal.py`: Read `EXA_API_KEY` from environment and include in MCP URL
- `compose.yaml`: Pass `EXA_API_KEY` to container (with empty default)
- `example.env`: Document the optional API key

**Behavior:**
- Without key: Works using Exa's demo mode (rate limited)
- With valid key: Uses user's Exa quota
- With invalid key: Returns 401 (Exa validates the key)

## Test Plan

- [x] Verified `exaApiKey` URL parameter is correct per Exa docs
- [x] Tested with valid API key - requests count against quota
- [x] Tested without API key - falls back to demo mode
- [x] Tested with invalid key - returns 401

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update