### PR TITLE
fix: URL-encode database password for special characters

### DIFF
--- a/db/url.py
+++ b/db/url.py
@@ -6,13 +6,14 @@ Build database connection URL from environment variables.
 """
 
 from os import getenv
+from urllib.parse import quote
 
 
 def build_db_url() -> str:
     """Build database URL from environment variables."""
     driver = getenv("DB_DRIVER", "postgresql+psycopg")
     user = getenv("DB_USER", "ai")
-    password = getenv("DB_PASS", "ai")
+    password = quote(getenv("DB_PASS", "ai"), safe="")  # URL-encode special chars
     host = getenv("DB_HOST", "localhost")
     port = getenv("DB_PORT", "5432")
     database = getenv("DB_DATABASE", "ai")


### PR DESCRIPTION
## Summary

Fixes database connection failures when passwords contain special characters like `@`, `:`, `/`, `#`, or `%`.

## Problem

SQLAlchemy parses connection URLs like:
```
postgresql://user:password@host:port/database
```

Special characters in passwords break this parsing:
```
Password: pass@word
URL: postgresql://ai:pass@word@localhost:5432/ai
                      ↑    ↑
                      │    └── SQLAlchemy thinks THIS is the host separator
                      └── Password ends here (wrong!)

Result: password="pass", host="word@localhost" ❌
```

## Solution

URL-encode the password using `urllib.parse.quote()`:
```python
from urllib.parse import quote
password = quote(getenv("DB_PASS", "ai"), safe="")
```

This converts special characters to percent-encoded equivalents:
- `@` → `%40`
- `:` → `%3A`  
- `/` → `%2F`
- `#` → `%23`
- `%` → `%25`

SQLAlchemy automatically decodes these when parsing.

## Testing

Tested with various passwords:
- `pass@word` ✅
- `P@ss:word#123` ✅
- `my/pass/word` ✅
- `test%percent` ✅
- `Railway@Auto#Gen!2024` ✅

Also tested full Docker deployment - app starts and connects to database successfully.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Tested locally with Docker