### PR TITLE
fix: use PORT env var for configurable port (default 8000)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,7 @@ Required:
 Optional:
 - `EXA_API_KEY` - Enables Pal's web research tools
 - `DB_DRIVER` - Database driver (default: `postgresql+psycopg`)
+- `PORT` - API server port (default: `8000`)
 - `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASS`, `DB_DATABASE`
 - `DATA_DIR` - DuckDB storage location (default: `/data`)
 - `RUNTIME_ENV` - Set to `dev` for auto-reload

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ python -m app.main
 |----------|----------|---------|-------------|
 | `OPENAI_API_KEY` | Yes | - | OpenAI API key |
 | `EXA_API_KEY` | No | - | Exa API key for web research (enables Pal's research tools) |
+| `PORT` | No | `8000` | API server port |
 | `DB_HOST` | No | `localhost` | Database host |
 | `DB_PORT` | No | `5432` | Database port |
 | `DB_USER` | No | `ai` | Database user |

--- a/scripts/railway_up.sh
+++ b/scripts/railway_up.sh
@@ -69,7 +69,8 @@ railway add --service agent_os \
     --variables "DB_DRIVER=postgresql+psycopg" \
     --variables "WAIT_FOR_DB=True" \
     --variables "DATA_DIR=/data" \
-    --variables "OPENAI_API_KEY=${OPENAI_API_KEY}"
+    --variables "OPENAI_API_KEY=${OPENAI_API_KEY}" \
+    --variables "PORT=8000"
 
 echo ""
 echo -e "${BOLD}Deploying application...${NC}"


### PR DESCRIPTION
## Summary

- Make PORT configurable via environment variable (default: 8000)
- Railway deployment sets `PORT=8000` to ensure proper proxy routing

## Changes

| File | Change |
|------|--------|
| `compose.yaml` | `${PORT:-8000}` - configurable via env |
| `railway.json` | `${PORT:-8000}` - uses env var |
| `railway_up.sh` | Sets `PORT=8000` for Railway |
| `Dockerfile` | `EXPOSE 8000` |
| `CLAUDE.md` | Updated port documentation |

## Why

Railway auto-detects ports 8080, 3000, 5000 but NOT 8000. By explicitly setting `PORT=8000`, Railway's proxy correctly routes traffic to the app.

## Testing

- ✅ Local: `docker compose up -d --build` → http://localhost:8000 works
- ✅ All endpoints verified: /health, /agents, /docs