### PR TITLE
fix: load .env file and add EXA_API_KEY support

### DIFF
--- a/scripts/railway_up.sh
+++ b/scripts/railway_up.sh
@@ -54,7 +54,7 @@ fi
 
 echo -e "${BOLD}Initializing project...${NC}"
 echo ""
-railway init -n "agno-agentos"
+railway init -n "agno"
 
 echo ""
 echo -e "${BOLD}Deploying PgVector database...${NC}"


### PR DESCRIPTION
## Summary

Updates `railway_up.sh` to automatically load environment variables from `.env` file, making it easier to deploy without manually exporting variables.

## Changes

- **Load .env file**: Script now sources `.env` if it exists before checking for required variables
- **Improved error message**: Better guidance when `OPENAI_API_KEY` is not set
- **EXA_API_KEY support**: Optionally passes `EXA_API_KEY` to Railway if set in environment

## Before

```bash
export OPENAI_API_KEY=sk-...
./scripts/railway_up.sh
```

## After

```bash
# Just create .env with your keys
cp example.env .env
# Edit .env with real keys
./scripts/railway_up.sh  # Works!
```