### PR TITLE
chore: remove --no-cache from venv setup install

### DIFF
--- a/scripts/venv_setup.sh
+++ b/scripts/venv_setup.sh
@@ -57,8 +57,8 @@ uv venv ${VENV_DIR} --python 3.12 --quiet
 
 echo ""
 echo -e "    ${DIM}Installing requirements...${NC}"
-echo -e "    ${DIM}> uv pip install -r requirements.txt --no-cache${NC}"
-VIRTUAL_ENV=${VENV_DIR} uv pip install -r ${REPO_ROOT}/requirements.txt --no-cache --quiet
+echo -e "    ${DIM}> uv pip install -r requirements.txt${NC}"
+VIRTUAL_ENV=${VENV_DIR} uv pip install -r ${REPO_ROOT}/requirements.txt --quiet
 
 echo ""
 echo -e "    ${DIM}Installing project in editable mode with dev dependencies...${NC}"


### PR DESCRIPTION
## Summary
- remove `--no-cache` from the venv setup install command output
- remove `--no-cache` from the actual `uv pip install -r requirements.txt` step in `scripts/venv_setup.sh`