### PR TITLE
[codex] add railway healthcheck and whatsapp deploy support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto eol=lf
+*.sh text eol=lf
+*.py text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+Dockerfile text eol=lf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,15 @@
 
 This file provides context for Claude Code when working with this repository.
 
+## IMPORTANT — Troubleshooting & Setup References
+
+**BEFORE diagnosing ANY error related to Docker, Docker Compose, WSL2, Agno/AgentOS startup, line endings, or Python deps in this repo, YOU MUST consult these files first:**
+
+- [`../TROUBLESHOOTING_DOCKER_COMPOSE.md`](../TROUBLESHOOTING_DOCKER_COMPOSE.md) — Catalog of 8 mapped errors with causes and fixes. Anti-patterns section lists known-bad routes to avoid.
+- [`../SETUP_DOCKER_COMPOSE.md`](../SETUP_DOCKER_COMPOSE.md) — The clean, validated setup path (11 steps). Use this as the reference flow; deviate only if the user requests.
+
+**Rule:** If a symptom matches an entry in TROUBLESHOOTING_DOCKER_COMPOSE.md, apply the documented fix directly — do NOT invent a new approach or re-diagnose from scratch. If you find a new error, add it to that file after resolving.
+
 ## Project Overview
 
 AgentOS - A multi-agent system built by Agno.

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ USER app
 EXPOSE 8000
 
 ENTRYPOINT ["/app/scripts/entrypoint.sh"]
-CMD ["chill"]
+CMD ["serve"]

--- a/README.md
+++ b/README.md
@@ -49,6 +49,109 @@ railway login
 
 The script provisions PostgreSQL, configures environment variables, and deploys your application.
 
+### Deploy to Railway via GitHub UI
+
+If you want to deploy directly from the Railway dashboard instead of the CLI, use this exact flow.
+
+#### 1. Create the AgentOS service from GitHub
+
+1. In Railway, click `New` -> `Deploy from GitHub repo`.
+2. Select this repository.
+3. If the template files are already at the repo root, leave `Root Directory` empty.
+4. If this code is inside a larger repo or monorepo, set `Root Directory` to `agentos-railway`.
+
+Railway builds from the source directory root. If the `Dockerfile` is not at that root, deployment fails unless you point Railway to the correct directory.
+
+#### 2. Add PostgreSQL to the same Railway project
+
+1. Click `New` -> `Database` -> `PostgreSQL`.
+2. Wait for provisioning to finish.
+3. Rename the database service to something simple like `postgres` if you want cleaner variable references.
+
+Railway exposes `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, `PGDATABASE`, and `DATABASE_URL` automatically for the database service.
+
+#### 3. Fill the `Settings` tab for the AgentOS service
+
+Use these values:
+
+| Section | Field | What to fill |
+|--------|-------|--------------|
+| Source | Source Repo | The GitHub repo you selected |
+| Source | Root Directory | Leave empty if the template is at repo root. Use `agentos-railway` only if the template is nested inside a larger repo |
+| Networking | Public Networking | Add `HTTP Proxy` |
+| Networking | HTTP target/internal port | `8000` |
+| Deploy | Pre-deploy Command | Leave empty |
+| Deploy | Custom Start Command | Leave empty |
+| Deploy | Healthcheck Path | `/health` |
+| Deploy | Restart Policy | `On Failure` |
+| Deploy | Restart retries | `10` |
+| Deploy | Replicas | `1` |
+
+Do not add `TCP Proxy` for the API service. This container exposes HTTP only.
+
+#### 4. Fill the `Variables` tab for the AgentOS service
+
+Add these variables:
+
+```dotenv
+OPENAI_API_KEY=sk-...
+DB_DRIVER=postgresql+psycopg
+WAIT_FOR_DB=True
+PORT=8000
+WHATSAPP_ENABLED=false
+DB_HOST=${{postgres.PGHOST}}
+DB_PORT=${{postgres.PGPORT}}
+DB_USER=${{postgres.PGUSER}}
+DB_PASS=${{postgres.PGPASSWORD}}
+DB_DATABASE=${{postgres.PGDATABASE}}
+```
+
+Important:
+
+- Replace `postgres` in `${{postgres.PGHOST}}` with the exact Railway service name of your PostgreSQL service.
+- The Railway variables UI autocompletes references. Use the autocomplete instead of typing these references manually.
+- `OPENAI_API_KEY` is the only required secret for the default template.
+- `PORT=8000` keeps the HTTP proxy, healthcheck, and the container aligned.
+
+Optional model provider variables:
+
+```dotenv
+ANTHROPIC_API_KEY=sk-ant-...
+GOOGLE_API_KEY=...
+```
+
+Only add the WhatsApp variables if you are enabling the WhatsApp interface:
+
+```dotenv
+WHATSAPP_ENABLED=true
+WHATSAPP_ACCESS_TOKEN=...
+WHATSAPP_PHONE_NUMBER_ID=...
+WHATSAPP_VERIFY_TOKEN=...
+WHATSAPP_APP_SECRET=...
+```
+
+If `WHATSAPP_ENABLED=true` and one of those values is missing, the container now fails fast on startup instead of booting with a broken webhook configuration.
+
+#### 5. Deploy and validate
+
+1. Click `Deploy`.
+2. Open the generated Railway domain.
+3. Check:
+   - `https://<your-domain>/health`
+   - `https://<your-domain>/docs`
+4. In `os.agno.com`, connect the deployment using the live Railway URL.
+
+#### 6. Where each value comes from
+
+| Value | Where you get it |
+|-------|-------------------|
+| `OPENAI_API_KEY` | OpenAI Platform dashboard |
+| `DB_*` variables | Railway Postgres reference variables |
+| `PORT` | Fixed manually to `8000` for this container |
+| `Healthcheck Path` | This repo exposes `/health` |
+| `Custom Start Command` | Leave blank because the container starts AgentOS by default |
+| `WHATSAPP_*` variables | Meta Developers -> your app -> WhatsApp -> API Setup |
+
 ### Connect to the Web UI
 
 1. Open [os.agno.com](https://os.agno.com)
@@ -200,6 +303,12 @@ python -m app.main
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `OPENAI_API_KEY` | Yes | - | OpenAI API key |
+| `WHATSAPP_ENABLED` | No | `false` | Enables the live WhatsApp interface. Leave disabled for local tests/dev. |
+| `WHATSAPP_ACCESS_TOKEN` | No | - | Meta WhatsApp Cloud API access token. Required only when `WHATSAPP_ENABLED=true`. |
+| `WHATSAPP_PHONE_NUMBER_ID` | No | - | Meta WhatsApp phone number id. Required only when `WHATSAPP_ENABLED=true`. |
+| `WHATSAPP_VERIFY_TOKEN` | No | - | Webhook verification token. Required only when `WHATSAPP_ENABLED=true`. |
+| `WHATSAPP_APP_SECRET` | No | - | Meta app secret for webhook signature validation. Required only when `WHATSAPP_ENABLED=true`. |
+| `WHATSAPP_SKIP_SIGNATURE_VALIDATION` | No | `false` | Local-only escape hatch when testing webhooks without `WHATSAPP_APP_SECRET`. |
 | `PORT` | No | `8000` | API server port |
 | `DB_HOST` | No | `localhost` | Database host |
 | `DB_PORT` | No | `5432` | Database port |

--- a/app/interfaces.py
+++ b/app/interfaces.py
@@ -1,0 +1,61 @@
+"""Interface builders for AgentOS."""
+
+from __future__ import annotations
+
+from os import getenv
+from typing import Any
+
+from agno.os.interfaces.whatsapp import Whatsapp
+
+_TRUTHY_VALUES = {"1", "true", "yes", "on"}
+_PLACEHOLDER_PREFIXES = ("your ",)
+_WHATSAPP_REQUIRED_ENV_VARS = (
+    "WHATSAPP_ACCESS_TOKEN",
+    "WHATSAPP_PHONE_NUMBER_ID",
+    "WHATSAPP_VERIFY_TOKEN",
+)
+
+
+def _is_enabled(env_var: str) -> bool:
+    value = getenv(env_var, "").strip().lower()
+    return value in _TRUTHY_VALUES
+
+
+def _is_placeholder(value: str) -> bool:
+    normalized = value.strip().lower()
+    return not normalized or normalized.startswith(_PLACEHOLDER_PREFIXES)
+
+
+def _missing_whatsapp_settings() -> list[str]:
+    missing: list[str] = []
+    for env_var in _WHATSAPP_REQUIRED_ENV_VARS:
+        value = getenv(env_var, "")
+        if _is_placeholder(value):
+            missing.append(env_var)
+    if not _is_enabled("WHATSAPP_SKIP_SIGNATURE_VALIDATION") and _is_placeholder(getenv("WHATSAPP_APP_SECRET", "")):
+        missing.append("WHATSAPP_APP_SECRET")
+    return missing
+
+
+def build_interfaces(agent: Any) -> list[Whatsapp]:
+    """Build external interfaces without enabling networked integrations by accident."""
+
+    if not _is_enabled("WHATSAPP_ENABLED"):
+        return []
+
+    missing = _missing_whatsapp_settings()
+    if missing:
+        missing_vars = ", ".join(missing)
+        raise RuntimeError(
+            "WHATSAPP_ENABLED=true but these WhatsApp settings are missing or still placeholders: "
+            f"{missing_vars}"
+        )
+
+    return [
+        Whatsapp(
+            agent=agent,
+            access_token=getenv("WHATSAPP_ACCESS_TOKEN"),
+            phone_number_id=getenv("WHATSAPP_PHONE_NUMBER_ID"),
+            verify_token=getenv("WHATSAPP_VERIFY_TOKEN"),
+        )
+    ]

--- a/app/main.py
+++ b/app/main.py
@@ -10,11 +10,13 @@ Run:
 
 from os import getenv
 from pathlib import Path
+from typing import Any
 
 from agno.os import AgentOS
 
 from agents.knowledge_agent import knowledge_agent
 from agents.mcp_agent import mcp_agent
+from app.interfaces import build_interfaces
 from db import get_postgres_db
 
 # ---------------------------------------------------------------------------
@@ -26,10 +28,22 @@ agent_os = AgentOS(
     scheduler=True,
     db=get_postgres_db(),
     agents=[knowledge_agent, mcp_agent],
+    interfaces=build_interfaces(knowledge_agent),
     config=str(Path(__file__).parent / "config.yaml"),
 )
 
 app = agent_os.get_app()
+
+
+@app.get("/health", tags=["Ops"])
+def healthcheck() -> dict[str, Any]:
+    """Lightweight liveness endpoint for Railway healthchecks."""
+
+    return {
+        "status": "ok",
+        "service": "agentos",
+        "runtime_env": getenv("RUNTIME_ENV", "prd"),
+    }
 
 if __name__ == "__main__":
     agent_os.serve(

--- a/compose.yaml
+++ b/compose.yaml
@@ -41,6 +41,12 @@ services:
       - PRINT_ENV_ON_LOAD=True
       # API keys
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - WHATSAPP_ENABLED=${WHATSAPP_ENABLED:-false}
+      # WhatsApp Cloud API
+      - WHATSAPP_ACCESS_TOKEN=${WHATSAPP_ACCESS_TOKEN}
+      - WHATSAPP_PHONE_NUMBER_ID=${WHATSAPP_PHONE_NUMBER_ID}
+      - WHATSAPP_VERIFY_TOKEN=${WHATSAPP_VERIFY_TOKEN}
+      - WHATSAPP_APP_SECRET=${WHATSAPP_APP_SECRET}
     depends_on:
       - agentos-db
     networks:

--- a/example.env
+++ b/example.env
@@ -1,9 +1,22 @@
 # Required (default configured for OpenAI)
-OPENAI_API_KEY=sk-***
+# OPENAI_API_KEY=sk-***
 
 # Optional: Use a different model provider
 # ANTHROPIC_API_KEY=sk-ant-***
 # GOOGLE_API_KEY=***
+
+# WhatsApp Cloud API (disabled by default to keep tests/dev from hitting Meta)
+# Set WHATSAPP_ENABLED=true only when you want the live integration enabled.
+WHATSAPP_ENABLED=false
+# Get these from https://developers.facebook.com -> your app -> WhatsApp > API Setup
+# APP_SECRET_KEY=your-app-secret-key
+# WHATSAPP_ACCESS_TOKEN=your-access-token
+# WHATSAPP_PHONE_NUMBER_ID=your-phone-number-id
+# WHATSAPP_VERIFY_TOKEN=your-verify-token
+# WHATSAPP_APP_SECRET=your-app-secret
+# Optional for local webhook debugging only. Do not enable in production.
+# WHATSAPP_SKIP_SIGNATURE_VALIDATION=true
+
 
 # Database (defaults work out of the box)
 # DB_USER=ai

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "psycopg[binary]",
   "sqlalchemy",
   "mcp",
+  "requests",
   "opentelemetry-api",
   "opentelemetry-sdk",
   "openinference-instrumentation-agno",

--- a/railway.json
+++ b/railway.json
@@ -7,7 +7,8 @@
   "deploy": {
     "runtime": "V2",
     "numReplicas": 1,
-    "startCommand": "uvicorn app.main:app --host 0.0.0.0 --port 8000",
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 120,
     "sleepApplication": false,
     "useLegacyStacker": false,
     "limits": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,6 +64,8 @@ python-multipart==0.0.22
 pytz==2025.2
 pyyaml==6.0.3
 referencing==0.37.0
+requests==2.32.3
+charset-normalizer==3.4.0
 rich==14.3.3
 rich-toolkit==0.19.7
 rignore==0.7.6

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -37,12 +37,20 @@ if [[ "$WAIT_FOR_DB" = true || "$WAIT_FOR_DB" = True ]]; then
     echo ""
 fi
 
+PORT_VALUE="${PORT:-8000}"
+
 case "$1" in
     chill)
         echo -e "    ${DIM}Mode: chill${NC}"
         echo -e "    ${BOLD}Container running.${NC}"
         echo ""
         while true; do sleep 18000; done
+        ;;
+    serve)
+        echo -e "    ${DIM}Mode: serve${NC}"
+        echo -e "    ${BOLD}Starting AgentOS on 0.0.0.0:${PORT_VALUE}.${NC}"
+        echo ""
+        exec uvicorn app.main:app --host 0.0.0.0 --port "$PORT_VALUE"
         ;;
     *)
         echo -e "    ${DIM}> $@${NC}"

--- a/scripts/railway_up.sh
+++ b/scripts/railway_up.sh
@@ -77,6 +77,11 @@ railway add --service agent-os \
     --variables "DB_DRIVER=postgresql+psycopg" \
     --variables "WAIT_FOR_DB=True" \
     --variables "OPENAI_API_KEY=${OPENAI_API_KEY}" \
+    --variables "WHATSAPP_ENABLED=${WHATSAPP_ENABLED:-false}" \
+    --variables "WHATSAPP_ACCESS_TOKEN=${WHATSAPP_ACCESS_TOKEN}" \
+    --variables "WHATSAPP_PHONE_NUMBER_ID=${WHATSAPP_PHONE_NUMBER_ID}" \
+    --variables "WHATSAPP_VERIFY_TOKEN=${WHATSAPP_VERIFY_TOKEN}" \
+    --variables "WHATSAPP_APP_SECRET=${WHATSAPP_APP_SECRET}" \
     --variables "PORT=8000"
 
 echo ""

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -1,0 +1,58 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from app.interfaces import build_interfaces
+
+
+class BuildInterfacesTestCase(unittest.TestCase):
+    def test_returns_no_interfaces_when_whatsapp_is_disabled(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(build_interfaces(agent=object()), [])
+
+    def test_raises_when_whatsapp_is_enabled_but_not_configured(self) -> None:
+        with patch.dict(os.environ, {"WHATSAPP_ENABLED": "true"}, clear=True):
+            with self.assertRaises(RuntimeError) as context:
+                build_interfaces(agent=object())
+
+        self.assertIn("WHATSAPP_ENABLED=true", str(context.exception))
+        self.assertIn("WHATSAPP_ACCESS_TOKEN", str(context.exception))
+
+    def test_builds_whatsapp_interface_when_enabled_and_configured(self) -> None:
+        env = {
+            "WHATSAPP_ENABLED": "true",
+            "WHATSAPP_ACCESS_TOKEN": "token-value",
+            "WHATSAPP_PHONE_NUMBER_ID": "phone-id",
+            "WHATSAPP_VERIFY_TOKEN": "verify-token",
+            "WHATSAPP_APP_SECRET": "app-secret",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with patch("app.interfaces.Whatsapp", autospec=True) as whatsapp_cls:
+                interfaces = build_interfaces(agent="knowledge-agent")
+
+        whatsapp_cls.assert_called_once_with(
+            agent="knowledge-agent",
+            access_token="token-value",
+            phone_number_id="phone-id",
+            verify_token="verify-token",
+        )
+        self.assertEqual(interfaces, [whatsapp_cls.return_value])
+
+    def test_allows_signature_validation_skip_without_app_secret(self) -> None:
+        env = {
+            "WHATSAPP_ENABLED": "true",
+            "WHATSAPP_ACCESS_TOKEN": "token-value",
+            "WHATSAPP_PHONE_NUMBER_ID": "phone-id",
+            "WHATSAPP_VERIFY_TOKEN": "verify-token",
+            "WHATSAPP_SKIP_SIGNATURE_VALIDATION": "true",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with patch("app.interfaces.Whatsapp", autospec=True) as whatsapp_cls:
+                interfaces = build_interfaces(agent="knowledge-agent")
+
+        whatsapp_cls.assert_called_once()
+        self.assertEqual(interfaces, [whatsapp_cls.return_value])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
- adds a `/health` endpoint and aligns Railway startup with a `serve` entrypoint and `PORT`
- adds guarded WhatsApp interface bootstrap plus tests so the integration only activates when explicitly configured
- documents GitHub-based Railway deployment, required variables, and safe example environment values
- adds `.gitattributes` to normalize LF for shell/python/docker files

## Why
The template needed a safer Railway deployment path and a fail-fast WhatsApp configuration flow without leaking secrets or enabling networked integrations by accident.

## Impact
Users can deploy from Railway with health checks configured, wire optional WhatsApp credentials explicitly, and avoid broken startup states caused by partial configuration.

## Validation
- `python -m unittest discover -s tests -p 'test_*.py'`
- manual staged secret review to ensure `.env` stayed ignored and only placeholder/example values are committed
