### PR TITLE
docs: refine claude-code prompts based on test-run findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,8 +80,6 @@ Every agent file has the same shape:
 =============
 """
 
-from __future__ import annotations
-
 from agno.agent import Agent
 
 from app.settings import default_model
@@ -131,7 +129,7 @@ Knowledge bases use PgVector with `SearchType.hybrid` and `text-embedding-3-smal
 Two options:
 
 1. **Hand it to Claude Code** — paste `Run docs/create-new-agent.md` into a Claude Code session pointed at this repo. Claude asks the user what the agent should do, generates the file, registers it, smoke-tests it.
-2. **Do it manually** — create `agents/<slug>.py`, register in `app/main.py`, add prompts to `app/config.yaml`. Hot-reload picks the new agent up automatically.
+2. **Do it manually** — create `agents/<slug>.py`, register in `app/main.py`, add prompts to `app/config.yaml`. Then `docker compose restart agentos-api` — uvicorn hot-reload is unreliable for newly-registered modules, so a restart is required for the new agent to load.
 
 ## Improving an agent
 

--- a/docs/create-new-agent.md
+++ b/docs/create-new-agent.md
@@ -7,14 +7,13 @@ You are creating a new agent in this AgentOS template. The user already has the 
 
 ## 0. Preconditions
 
-- `agentos-api` container is up: `docker compose ps` should show it running.
-- `curl -sSf http://localhost:8000/health` returns 200.
+- Live container reachable: `curl -sSf http://localhost:8000/health` returns 200. (`docker compose ps` is unreliable from worktrees or alternate clones — trust the health probe.)
 
-If either is missing, ask the user to run `docker compose up -d --build` and wait for it to come up.
+If it isn't reachable, ask the user to run `docker compose up -d --build` and wait for it to come up.
 
 ## 1. Ask the user
 
-**How to ask:** Use the `AskUserQuestion` tool for choice-shaped prompts — the branching opener, the role pick, the systems multiselect, the agent-idea suggestions, and the **Pattern** pick are all good fits. It renders click-to-select buttons, much smoother than parsing free-text replies. Use plain prompts only for free-form fields (the recurring-task description, the slug).
+**Ask via the `AskUserQuestion` tool** for every choice-shaped prompt below — the branching opener, the role pick, the systems multiselect, the agent-idea suggestions, and the **Pattern** pick. It renders click-to-select buttons, much smoother than parsing free-text replies. Use plain prompts only for free-form fields (the recurring-task description, the slug).
 
 Open with a single branching question — don't dump five questions at once:
 
@@ -66,6 +65,8 @@ For each toolkit, capture four things:
 - **Constructor args** that matter for this agent (categories, domains, max_results, etc.).
 - **Required env vars** — feed these back into Step 1, item 4.
 - **Pip dependencies** — some toolkits need extra packages (`exa-py`, `anthropic`, `firecrawl-py`, `linear-sdk`, …). The toolkit's `Prerequisites` section lists them. Capture now, install in Step 6.
+
+If the toolkit's docs page has no `Prerequisites` or `Authentication` section, the toolkit is keyless and needs no env vars or extra pip deps (e.g. HackerNews, ArXiv, Wikipedia, DuckDuckGo).
 
 Don't guess any of the four. Skip this step entirely if the agent is chat-only with no tools.
 
@@ -179,12 +180,14 @@ jq -r '.content // .' < /tmp/agent-out.json
 Check the container logs to see which tools fired:
 
 ```bash
-docker logs agentos-api --since 30s 2>&1 | grep -E "Tool Calls|Running:|Error" | head -40
+docker logs agentos-api --since 30s 2>&1 | grep -E "Running: \w+\(" | head -40
 ```
+
+(`Running: <tool>(` is the line shape agno emits per tool call when `AGNO_DEBUG=True`, which compose sets for dev. Without `AGNO_DEBUG`, expect no matches — `HTTP 200` and a non-empty body are then your only signal.)
 
 ## 8. If the smoke test fails
 
-- **HTTP 404** — the agent isn't registered, or the container wasn't restarted. Re-check Step 4 and Step 6.
+- **HTTP 404** — the agent isn't registered, the container wasn't restarted, or your edits aren't reaching the bind-mount. Re-check Step 4 and Step 6. If both look right, run `docker inspect agentos-api --format '{{ range .Mounts }}{{ .Source }} → {{ .Destination }}{{ "\n" }}{{ end }}'` to confirm `/app` is bound to *this* repo's path (a stale clone or a different worktree is a common cause).
 - **HTTP 5xx** — read `docker logs agentos-api --tail 50` for the traceback. Most failures are import errors, missing env vars, or a typo in the agent's `tools=` list.
 - **Empty response** — check the logs for tool call errors (rate limits, missing API keys, MCP server unreachable). Surface the issue to the user; don't paper over it.
 - **Tool not firing when expected** — the instruction prompt isn't strong enough. Tell the user; suggest tightening or running `docs/improve-agent.md` once the agent is loaded.

--- a/docs/create-new-agent.md
+++ b/docs/create-new-agent.md
@@ -145,9 +145,9 @@ chat:
 
 ## 6. Reload the container
 
-Hot-reload is unreliable for newly registered agents — uvicorn's reloader doesn't always re-import top-level modules cleanly, so the agent may register but its toolkit state caches stale. Always reload the container after Step 4. Two paths:
+After Step 4, **always restart the container** — uvicorn's hot-reload doesn't reliably pick up newly registered modules.
 
-- **No new pip deps** (the common case) — restart only:
+- **No new pip deps** (the common case):
 
   ```bash
   docker compose restart agentos-api
@@ -160,9 +160,17 @@ Hot-reload is unreliable for newly registered agents — uvicorn's reloader does
   docker compose up -d --build
   ```
 
+Then verify the agent shows up in the registry before smoke-testing:
+
+```bash
+curl -s http://localhost:8000/agents | jq -r '.[].id' | grep <slug>
+```
+
+If `<slug>` isn't in the list, the restart didn't pick up your edits — jump to Step 8.
+
 ## 7. Smoke test
 
-Poll `/health` until the API is back up, then probe the agent with **one of the quick prompts you wrote in Step 5** (so the smoke test exercises what real users will hit):
+Poll `/health` until the API is back up, then probe the agent with **one of the quick prompts you wrote in Step 5** (so the smoke test exercises what real users will hit). Substitute `<slug>` and the `message=` value before running:
 
 ```bash
 until curl -sSf http://localhost:8000/health > /dev/null; do sleep 0.5; done
@@ -176,6 +184,8 @@ curl -sS -X POST http://localhost:8000/agents/<slug>/runs \
 
 jq -r '.content // .' < /tmp/agent-out.json
 ```
+
+Pass = `HTTP 200` and a non-empty `.content` field.
 
 Check the container logs to see which tools fired:
 
@@ -198,7 +208,7 @@ Iterate at most 2-3 times on the prompt before stopping and surfacing the questi
 
 When the smoke test passes:
 
-1. Tell the user the agent's slug and the URL: `https://os.agno.com` (their already-connected OS) — they can chat with the new agent immediately.
+1. Tell the user the agent's slug. They can chat with it at `https://os.agno.com` (if their OS is connected there) or against `http://localhost:8000` directly for local-only.
 2. Mention `docs/improve-agent.md` for the next-step iteration loop if behavior needs tuning.
 
 A simple agent usually takes 5-10 minutes from "Run docs/create-new-agent.md" to working. More if the user asks for custom tools or an MCP server with auth.

--- a/docs/eval-and-improve.md
+++ b/docs/eval-and-improve.md
@@ -7,9 +7,9 @@ You're running the agent platform's eval suite, diagnosing every failure, fixing
 
 ## 0. Preconditions
 
-- Postgres up: `docker compose ps` shows `agentos-db`. If not, `docker compose up -d agentos-db`.
-- Venv active: `source .venv/bin/activate`. `evals/cases.py` imports the agents directly from `agents/`, so no AgentOS server has to be running.
-- `.env` populated with `OPENAI_API_KEY` (and `PARALLEL_API_KEY` if you have one — the runner pins the expected web-search tool name based on it). `evals/__main__.py` calls `evals.dotenv.load_dotenv()` at startup, so you do not need to source `.env` first.
+- Postgres reachable on 5432: `nc -z localhost 5432` returns 0. If not, `docker compose up -d agentos-db` from the source repo. (`docker compose ps` is unreliable from worktrees or alternate clones.)
+- Venv active: `source .venv/bin/activate`. If `.venv` doesn't exist (fresh checkout or worktree), run `./scripts/venv_setup.sh` first. `evals/cases.py` imports the agents directly from `agents/`, so no AgentOS server has to be running.
+- `.env` populated with `OPENAI_API_KEY` (and `PARALLEL_API_KEY` if you have one — the runner pins the expected web-search tool name based on it). `evals/__main__.py` calls `evals.dotenv.load_dotenv()` at startup, so you do not need to source `.env` first. Worktrees don't inherit `.env` (it's gitignored) — copy it from the source repo if missing.
 
 ## 1. Run the suite
 
@@ -31,10 +31,13 @@ For every failed case, decide which kind of failure it is and fix at the appropr
 | Judge fails, response is fabricated | Agent hallucinated when it should have said it didn't know | Add a "if you can't find a real source, say so plainly" rule to the agent's instructions |
 | Reliability fails: "missing tool X" | Agent didn't call the expected tool on this prompt | (a) Strengthen the routing rule in instructions, OR (b) the case is too narrow — broaden `expected_tool_calls` or drop the assertion |
 | Reliability fails: "additional tool Y called" with `allow_additional_tool_calls=False` | Agent fanned out beyond the case's expectation | Tighten the agent's instructions OR set `allow_additional_tool_calls=True` |
+| Single case fails on full suite but passes alone | Transient flake or upstream rate limit (429s, MCP shutdown traceback) | Re-run the case in isolation. If it passes, re-run the full suite. If 429s persist, back off — don't fix the agent. |
 | Many cases fail at once | Broad regression — model swap, MCP server down, tool removed | Diagnose the root cause first; do NOT paper over with prompt edits |
 | `eval_db` write errors | Postgres down or migration missing | Bring DB up; check `docker logs agentos-db` |
 
 **Rule:** never weaken a case to make it green. Edit a case only when the assertion was wrong (overspecified rubric, wrong tool name, mismatch with how the agent's tools are named today). Catching a real regression is the whole point.
+
+Quick test for "wrong assertion vs. real regression": read the response yourself. If it looks correct against the user's intent but the rubric flagged a missing detail, the rubric was overspecified. If the response is genuinely wrong, the agent's instructions need work.
 
 ## 3. Fix scope
 
@@ -66,7 +69,7 @@ When all targeted cases pass, run the full suite once more to confirm nothing re
 python -m evals
 ```
 
-Stop when `python -m evals` exits 0.
+Stop when `python -m evals` exits 0 **and** prints an `Eval Summary` block. If a re-run aborts mid-stream (no summary, regardless of exit code), treat it as inconclusive — re-run before declaring green.
 
 ## 5. Add a new case (if needed)
 
@@ -111,3 +114,5 @@ class Case:
 ```
 
 The runner calls `agent.arun()` once per case and feeds the response into both checks, so cases that set both fields cost one agent run, not two.
+
+`evals/cases.py` also conditions one expected tool name on `PARALLEL_API_KEY` (web-search uses Parallel SDK if the key is set, keyless MCP otherwise). If your shell has the var set but `.env` doesn't (or vice versa), the assertion checks the wrong tool — sync them before debugging.

--- a/docs/eval-and-improve.md
+++ b/docs/eval-and-improve.md
@@ -21,6 +21,8 @@ python -m evals --case <name> # single case while iterating
 
 Output ends with a summary block. Exit code is 0 on all-pass, non-zero on any failure or error.
 
+Stderr noise around MCP teardown (`RuntimeError: Event loop is closed`, httpx timeouts) at the end of a run is harmless — only the `Eval Summary` table and exit code count.
+
 ## 2. Diagnose each failure
 
 For every failed case, decide which kind of failure it is and fix at the appropriate layer:
@@ -31,6 +33,8 @@ For every failed case, decide which kind of failure it is and fix at the appropr
 | Judge fails, response is fabricated | Agent hallucinated when it should have said it didn't know | Add a "if you can't find a real source, say so plainly" rule to the agent's instructions |
 | Reliability fails: "missing tool X" | Agent didn't call the expected tool on this prompt | (a) Strengthen the routing rule in instructions, OR (b) the case is too narrow — broaden `expected_tool_calls` or drop the assertion |
 | Reliability fails: "additional tool Y called" with `allow_additional_tool_calls=False` | Agent fanned out beyond the case's expectation | Tighten the agent's instructions OR set `allow_additional_tool_calls=True` |
+| Reliability fails on web-search tool name (`parallel_search` ↔ `web_search`) | `PARALLEL_API_KEY` mismatch between `.env` and your shell — `evals/cases.py` pins `_WEB_SEARCH_TOOL` at import time | Sync the var in both places, then re-run |
+| Same case flips PASS/FAIL across consecutive runs with no code change | Judge variance — rubric is too loose | Re-run 2-3 times to confirm; if it keeps flipping, tighten the case's `criteria` (more specific, more falsifiable) |
 | Single case fails on full suite but passes alone | Transient flake or upstream rate limit (429s, MCP shutdown traceback) | Re-run the case in isolation. If it passes, re-run the full suite. If 429s persist, back off — don't fix the agent. |
 | Many cases fail at once | Broad regression — model swap, MCP server down, tool removed | Diagnose the root cause first; do NOT paper over with prompt edits |
 | `eval_db` write errors | Postgres down or migration missing | Bring DB up; check `docker logs agentos-db` |

--- a/docs/improve-agent.md
+++ b/docs/improve-agent.md
@@ -11,8 +11,7 @@ This is a **single-pass** improvement loop. One pass usually takes 15-30 minutes
 
 ## 0. Preconditions
 
-- `agentos-api` running: `docker compose ps`. If not, ask the user to `docker compose up -d --build` first.
-- `curl -sSf http://localhost:8000/health` returns 200.
+- Live container reachable: `curl -sSf http://localhost:8000/health` returns 200. If not, ask the user to `docker compose up -d --build` first. (`docker compose ps` is unreliable from worktrees or alternate clones — trust the health probe.)
 - Ask the user for the target agent **slug** (e.g. `web-search`).
 - Recommend the user create a feature branch (`git checkout -b improve/<slug>-$(date +%Y%m%d)`) so any wrong turns are easy to revert.
 
@@ -28,23 +27,23 @@ Restate the agent's purpose to the user in 1-2 sentences before generating probe
 
 ## 2. Derive probes
 
-Generate enough probes to meaningfully exercise the agent's stated capabilities — usually **8-15**, more if the surface area is broad. Cover four categories:
+Generate enough probes to meaningfully exercise the agent's stated capabilities — aim for **2-3 per distinct rule in `INSTRUCTIONS`, plus 2 adversarial probes**. Most agents in this repo land at 8-12. Cover four categories:
 
 - **Golden path** (3-5): typical, in-scope questions the agent should handle well.
 - **Edge cases** (2-3): ambiguous, out-of-scope, or boundary questions. The agent should handle these gracefully — admit ignorance, refuse, or ask for clarification, not fabricate.
 - **Tool selection** (2-3): questions designed to test that the *right* tool fires (and the wrong one doesn't).
 - **Adversarial** (1-2): prompt injection attempts, malformed input, questions designed to confuse the agent or pull it off-purpose.
 
-For each probe, write a one-line **expected behavior** describing what "good" looks like — drawn from the agent's `INSTRUCTIONS`. *You* are the oracle here; don't ask the user to validate your judgment.
+For each probe, write a one-line **expected behavior** describing what "good" looks like — drawn from the agent's `INSTRUCTIONS`. *You* are the oracle here; don't ask the user to validate your judgment. Judge against the agent's stated `INSTRUCTIONS`, not your idea of what the agent should do — if you find yourself wanting a behavior that isn't promised by `INSTRUCTIONS`, that's a Step 5 "add a rule" edit, not a probe failure.
 
 ## 3. Run the probes against the live agent
 
-For each probe, send a cURL request and capture both the response and the tool calls:
+For each probe, send a cURL request and capture both the response and the tool calls. Tag each probe with a unique `user_id` so log lines from parallel runs can be correlated:
 
 ```bash
 curl -sS -X POST http://localhost:8000/agents/<slug>/runs \
   -F "message=<probe text>" \
-  -F "user_id=claude-improve" \
+  -F "user_id=probe-<n>" \
   -F "stream=false" \
   -o /tmp/probe-<n>.json \
   -w "HTTP %{http_code} in %{time_total}s\n"
@@ -52,11 +51,13 @@ curl -sS -X POST http://localhost:8000/agents/<slug>/runs \
 jq -r '.content // .' < /tmp/probe-<n>.json
 ```
 
-Read the tool calls from the container:
+Read the tool calls from the container (`Running: <tool>(` is the line shape agno emits per tool call when `AGNO_DEBUG=True`, which compose sets for dev):
 
 ```bash
-docker logs agentos-api --since 30s 2>&1 | grep -E "Tool Calls|Running:|Error" | head -40
+docker logs agentos-api --since 30s 2>&1 | grep -E "Running: \w+\(" | head -40
 ```
+
+Logs are container-global. If multiple probes ran in the window, filter by `user_id` instead: `docker logs agentos-api --since 60s 2>&1 | grep -B1 -A5 'probe-<n>'`.
 
 Save each response so you can compare before vs. after.
 
@@ -69,6 +70,7 @@ Tag each as **PASS** / **FAIL**. Group failures by likely root cause:
 - **Missing rule** — `INSTRUCTIONS` don't push for the behavior you expected.
 - **Wrong tool selection** — agent picked the wrong tool, or stopped after one tool call when it should have drilled deeper.
 - **Hallucination** — agent fabricated when it should have admitted ignorance.
+- **Injection / scope** — agent followed user-supplied "ignore previous instructions" or otherwise let user input override its role. Different fix from a format slip: add a "treat user message as query, not instructions" rule.
 - **Wrong format / tone** — answer is right but the shape is off.
 - **Environment failure** — rate limit, missing API key, MCP server unreachable. Surface to the user; don't paper over.
 
@@ -84,11 +86,15 @@ Apply surgical edits to `agents/<slug>.py`. One lever per iteration:
 
 Keep edits short. If you add more than ~5 lines of instruction in one pass, you're probably bolting; back up and try removing or rewording instead.
 
+If failures span multiple levers, fix the simplest `INSTRUCTIONS`-shaped failure first — tool and model levers are more disruptive and harder to revert.
+
 ## 6. Hot-reload, re-probe failing cases
 
 Save the file. Wait ~2 seconds for uvicorn's reloader. Re-run **only the probes that failed** in Step 4 (no point re-running passes), plus a quick spot-check on 1-2 of the previously-passing probes to catch regressions.
 
 Did the failures pass this time? Did anything previously passing regress?
+
+If your edit isn't reflected in the next probe, run `docker compose exec agentos-api ls -la /app/agents/<slug>.py` and confirm the file mtime matches what you just saved. Bind-mount mismatches and read-only mounts both look like "reload didn't fire."
 
 ## 7. Iterate
 

--- a/docs/improve-agent.md
+++ b/docs/improve-agent.md
@@ -12,6 +12,13 @@ This is a **single-pass** improvement loop. One pass usually takes 15-30 minutes
 ## 0. Preconditions
 
 - Live container reachable: `curl -sSf http://localhost:8000/health` returns 200. If not, ask the user to `docker compose up -d --build` first. (`docker compose ps` is unreliable from worktrees or alternate clones — trust the health probe.)
+- Live container is bound to *this* checkout — otherwise hot-reload won't see your edits:
+
+  ```bash
+  docker inspect agentos-api --format '{{range .Mounts}}{{.Source}}{{"\n"}}{{end}}' | grep -F "$(pwd)"
+  ```
+
+  Empty result = the container's `/app` is bound to a different repo path. Either `cd` to that repo or restart the container from this directory (`docker compose down && docker compose up -d --build`).
 - Ask the user for the target agent **slug** (e.g. `web-search`).
 - Recommend the user create a feature branch (`git checkout -b improve/<slug>-$(date +%Y%m%d)`) so any wrong turns are easy to revert.
 
@@ -90,11 +97,17 @@ If failures span multiple levers, fix the simplest `INSTRUCTIONS`-shaped failure
 
 ## 6. Hot-reload, re-probe failing cases
 
-Save the file. Wait ~2 seconds for uvicorn's reloader. Re-run **only the probes that failed** in Step 4 (no point re-running passes), plus a quick spot-check on 1-2 of the previously-passing probes to catch regressions.
+Save the file. Wait ~2 seconds for uvicorn's reloader. Before re-probing, confirm the edit reached the container:
+
+```bash
+docker exec agentos-api grep -c "<unique substring from your edit>" /app/agents/<slug>.py
+```
+
+`0` means the file in the container hasn't changed — almost always a bind-mount mismatch (Step 0 catches this earlier; if you skipped that check, run `docker exec agentos-api ls -la /app/agents/<slug>.py` and compare mtime to your save). Use `docker exec`, not `docker compose exec` — the latter needs a compose project context that worktrees don't have.
+
+Re-run **only the probes that failed** in Step 4 (no point re-running passes), plus a quick spot-check on 1-2 of the previously-passing probes to catch regressions.
 
 Did the failures pass this time? Did anything previously passing regress?
-
-If your edit isn't reflected in the next probe, run `docker compose exec agentos-api ls -la /app/agents/<slug>.py` and confirm the file mtime matches what you just saved. Bind-mount mismatches and read-only mounts both look like "reload didn't fire."
 
 ## 7. Iterate
 
@@ -111,7 +124,7 @@ Summarize for the user:
 - N probes generated, M passed initially, K passed finally.
 - One line per accepted edit (which lever, what changed).
 - `git diff agents/<slug>.py` (one short block).
-- Suggested commit message and next step (commit, regress, iterate).
+- Suggested commit message in the form `fix(<slug>): <one-line summary>`, and next step (commit, regress, iterate).
 
 For a regression check across the committed eval suite, see [`docs/eval-and-improve.md`](eval-and-improve.md).
 

--- a/docs/review-and-improve.md
+++ b/docs/review-and-improve.md
@@ -20,6 +20,7 @@ This is a **recurring sweep** — meant to be re-run regularly. On a clean repo 
 - New agent file on disk not yet imported in [`app/main.py`](../app/main.py) (add the import + append to `agents=[...]`).
 - Missing `quick_prompts` block for a registered agent (draft three from the agent's `INSTRUCTIONS`; flag the new entries so the user can refine).
 - Missing or wrong cross-links between `docs/*.md` files.
+- Single-line factual claim in one doc contradicted by another doc or by code (e.g. one doc says "hot-reload picks up new agents" while another says a restart is required) — auto-fix the doc, not the code.
 
 **Flag, don't fix** (surface for the user):
 

--- a/docs/review-and-improve.md
+++ b/docs/review-and-improve.md
@@ -15,7 +15,7 @@ This is a **recurring sweep** — meant to be re-run regularly. On a clean repo 
 
 - Stale file paths in any doc.
 - Missing entries in [`example.env`](../example.env) for env vars the code actually reads.
-- Stale entries in `example.env` for vars nothing reads (delete + note in the report — could be intentional).
+- Stale entries in `example.env` for vars nothing reads — delete unless the surrounding comment block describes them as optional/future ("alternate model providers", "future feature"). Flag instead of fixing if intent is unclear.
 - Architecture diagram in `AGENTS.md` / `README.md` missing a registered agent.
 - New agent file on disk not yet imported in [`app/main.py`](../app/main.py) (add the import + append to `agents=[...]`).
 - Missing `quick_prompts` block for a registered agent (draft three from the agent's `INSTRUCTIONS`; flag the new entries so the user can refine).
@@ -31,8 +31,8 @@ This is a **recurring sweep** — meant to be re-run regularly. On a clean repo 
 
 ## 0. Preconditions
 
-- `agentos-api` running: `docker compose ps`. If not, ask the user to `docker compose up -d --build` first — Step 4 needs a live container.
-- `curl -sSf http://localhost:8000/health` returns 200.
+- Live container reachable: `curl -sSf http://localhost:8000/health` returns 200. If not, ask the user to `docker compose up -d --build` first — Step 4 needs a live container. (`docker compose ps` is unreliable from worktrees or alternate clones — trust the health probe.)
+- If multiple worktrees of this repo exist on disk, only one container can bind to localhost:8000 — Step 4 will reflect whichever repo last brought the container up, not necessarily this worktree's `app/main.py`. Step 4 has a cross-check for this.
 - Recommend a feature branch so auto-fixes are easy to revert: `git checkout -b review/$(date +%Y%m%d)`.
 
 ## 1. Scope check
@@ -41,7 +41,7 @@ Restate the surface area in 4-5 lines so the user can redirect before you read e
 
 - Top-level docs: [`README.md`](../README.md), [`AGENTS.md`](../AGENTS.md), [`docs/*.md`](../docs/), [`example.env`](../example.env).
 - Code: [`app/`](../app/), [`agents/`](../agents/), [`db/`](../db/), [`evals/`](../evals/), [`scripts/`](../scripts/).
-- Configs: [`compose.yaml`](../compose.yaml), [`Dockerfile`](../Dockerfile), [`pyproject.toml`](../pyproject.toml), [`railway.json`](../railway.json), [`.mcp.json`](../.mcp.json).
+- Configs: [`compose.yaml`](../compose.yaml), [`Dockerfile`](../Dockerfile), [`pyproject.toml`](../pyproject.toml), [`railway.json`](../railway.json).
 
 Skip: `.venv/`, `*_cache/`, `.git/`, anything generated.
 
@@ -75,8 +75,18 @@ The bulk of the work. Diff each pair below; auto-fix per the rules at the top.
 | Architecture diagrams match registered agents | `README.md`, `AGENTS.md` Architecture sections | New agent missing from the tree |
 | Eval cases reference real agents + tools | `evals/cases.py` ↔ `agents/` | Slug renamed or tool removed |
 | `Key Files` table in `AGENTS.md` matches reality | `AGENTS.md` ↔ filesystem | Renamed file, deleted file, new file not listed |
+| Cross-links between `docs/*.md` files resolve | `docs/*.md` ↔ `docs/*.md` filenames | Renamed file, broken link |
+| `.mcp.json` servers and the docs that reference them agree | `.mcp.json` ↔ `docs/*.md` | URL changed, server renamed |
 
 ## 4. Live container smoke
+
+First, confirm the live container is serving *this* repo's agents — not a stale clone or a different worktree. Compare the API's registered agents against what you parsed from `app/main.py`:
+
+```bash
+curl -s http://localhost:8000/agents | jq -r '.[].id' | sort
+```
+
+If the list doesn't match the slugs in `agents=[...]`, flag it — Step 4 will be testing the wrong code. Common causes: the container is bound to a different repo path, or `docker compose restart` is needed. Stop and surface to the user.
 
 For each agent registered in `app/main.py`, hit it with one of its `quick_prompts`:
 
@@ -94,8 +104,10 @@ jq -r '.content // .' < /tmp/review-<slug>.json | head -20
 Pass = HTTP 200, non-empty content, no errors in the container logs:
 
 ```bash
-docker logs agentos-api --since 30s 2>&1 | grep -E "Tool Calls|Running:|Error" | head -40
+docker logs agentos-api --since 30s 2>&1 | grep -E "Running: \w+\(" | head -40
 ```
+
+(`Running: <tool>(` is the tool-call line shape agno emits when `AGNO_DEBUG=True`, which compose sets for dev. Without `AGNO_DEBUG` expect no matches — `HTTP 200` and a non-empty body are then your only signal.)
 
 Quality issues (response is plausible but wrong, missing citations, wrong tool fired) are out of scope — note them and recommend [`docs/improve-agent.md`](improve-agent.md).
 
@@ -115,11 +127,13 @@ source .venv/bin/activate  # if not already active
 
 > Run `python -m evals` to confirm no agent regressed? (Hits OpenAI; takes 1-3 minutes.)
 
-If yes, run the full suite. If any case fails, recommend [`docs/eval-and-improve.md`](eval-and-improve.md) — don't fix here.
+If yes, run `python -m evals`. If any case fails, add it to "Needs your call" with [`docs/eval-and-improve.md`](eval-and-improve.md) as the recommended follow-up. If the user declines, skip this step entirely — it does not affect the rest of the report.
 
 ## 7. Report
 
-Wrap up with three blocks, in order:
+If nothing was fixed and nothing flagged, skip the first two blocks below and just print: *"Repo is consistent and the live container is healthy. No follow-up needed."* No commit suggested.
+
+Otherwise, wrap up with three blocks, in order:
 
 **Fixed automatically** — one line per change, with file path. Terse.
 
@@ -132,6 +146,6 @@ git diff --stat
 ```
 
 - Suggested commit message — `chore: review-and-improve sweep` plus one short bullet per fix bucket.
-- Recommended follow-up — usually [`docs/improve-agent.md`](improve-agent.md) (if a live agent looked off) or [`docs/eval-and-improve.md`](eval-and-improve.md) (if evals failed). If nothing surfaced, just say "Repo is consistent and the live container is healthy. No follow-up needed."
+- Recommended follow-up — usually [`docs/improve-agent.md`](improve-agent.md) (if a live agent looked off) or [`docs/eval-and-improve.md`](eval-and-improve.md) (if evals failed).
 
-A clean sweep takes 3-5 minutes. A dirty one is 15-30, mostly because live smoke surfaces agent regressions you have to triage.
+A clean sweep takes 3-5 minutes (10+ if the venv needs to be created). A dirty one is 15-30, mostly because live smoke surfaces agent regressions you have to triage.


### PR DESCRIPTION
## Summary

Two commits to `docs/*.md`:

1. **Snapshot of in-flight revisions** the user had uncommitted — switched preconditions from `docker compose ps` (unreliable in worktrees) to direct `curl /health` / `nc -z`, broadened the `improve-agent` failure taxonomy, added the `Eval Summary` stop condition, etc.
2. **Refinements driven by actually running each prompt** as a Claude Code session inside isolated worktrees (one subagent per prompt, parallel runs). Findings filtered against #1 so this commit only contains improvements that survived the snapshot:
   - `create-new-agent.md` — promote `docker compose restart` to the leading action of Step 6 (skimmers were missing it and chasing 404s); add a post-restart `curl /agents | grep <slug>` registry check; annotate cURL placeholders; localhost fallback in Step 9.
   - `improve-agent.md` — Step 0 bind-mount precondition (catches "live container is bound to a different repo" before the user wastes a probe loop); replace `docker compose exec` with `docker exec` in Step 6 (the former fails in worktrees with no compose project context); post-save grep verification before re-probe; `fix(<slug>): …` commit-message template.
   - `eval-and-improve.md` — call out that stderr noise around MCP teardown (`RuntimeError: Event loop is closed`, httpx timeouts) is harmless; new diagnosis-table rows for `PARALLEL_API_KEY` mismatches and judge-variance flakes (the `code_search_admits_unknown_function` case flipped PASS→FAIL across consecutive runs with identical code during testing).
   - `review-and-improve.md` — new auto-fix bullet for "single-line factual claim in one doc contradicted by another doc or by code".

## Test plan

- [x] Each prompt was executed end-to-end by a subagent in an isolated worktree against the live `agentos-api` container.
- [x] `git diff --stat` reviewed; only docs touched (no code changes).
- [ ] Reviewer: skim each diff and confirm the refinement matches the friction described.
- [ ] (Optional) Re-run any of the prompts after merge to confirm the friction is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)